### PR TITLE
 implementação do icone  de olho para mostrar/ocultar password

### DIFF
--- a/components/login-form.tsx
+++ b/components/login-form.tsx
@@ -10,18 +10,25 @@ import { Input } from "@/components/ui/input"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { useAuth } from "@/hooks/use-auth"
 import { LoadingButton } from "./loading-button"
-import { LogIn } from "lucide-react"
+import { Eye, EyeOff, LogIn } from "lucide-react"
 
 export function LoginForm() {
   const router = useRouter()
   const { login, loading, error } = useAuth()
   const [formData, setFormData] = useState({ email: "", password: "" })
   const [formError, setFormError] = useState("")
+  const [showPassword, setShowPasword] = useState(false)
+
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
     setFormData((prev) => ({ ...prev, [name]: value }))
   }
+
+  function togglePassword() {
+    setShowPasword(prev => !prev);
+  }
+
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -72,16 +79,28 @@ export function LoginForm() {
             <label htmlFor="password" className="block text-sm font-medium mb-2">
               Senha
             </label>
-            <Input
-              id="password"
-              name="password"
-              type="password"
-              placeholder="••••••••"
-              value={formData.password}
-              onChange={handleChange}
-              disabled={loading}
-              className="bg-secondary border-border"
-            />
+            <div className="relative">
+              <Input
+                id="password"
+                name="password"
+                type={showPassword ? "text" : "password"}
+                placeholder="••••••••"
+                value={formData.password}
+                onChange={handleChange}
+                disabled={loading}
+                className="bg-secondary border-border pr-10"
+              />
+              <button
+                type="button"
+                onClick={togglePassword}
+                aria-label={showPassword ? "ocultar senha" : "Mostrar senha "}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500  cursor-pointer  "
+
+              >
+                {showPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5 " />}
+
+              </button>
+            </div>
           </div>
           <LoadingButton type="submit" loading={loading} className="w-full bg-accent hover:bg-accent/90 cursor-pointer">
             <LogIn />

--- a/components/register-form.tsx
+++ b/components/register-form.tsx
@@ -24,7 +24,7 @@ import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/use-auth";
 import { LoadingButton } from "./loading-button";
 import { TermsModal } from "./terms-modal";
-import { LogIn } from "lucide-react";
+import { Eye, EyeOff, LogIn } from "lucide-react";
 import { COUNTRIES_WITH_DDI, getDDIByCountry } from "@/lib/country-data";
 
 export function RegisterForm() {
@@ -50,6 +50,19 @@ export function RegisterForm() {
     termsAccepted: false,
     ddi: "",
   });
+
+  const [showPassword, setSwowPasword] = useState(false)
+  const [showConfirmPassword, setShowComfirmPassword] = useState(false)
+
+
+
+  function togglePassword() {
+    setSwowPasword(prev => !prev);
+  }
+
+  function toggleConfimPassword() {
+    setShowComfirmPassword(prev => !prev);
+  }
 
   /* =====================
      Input handler
@@ -333,24 +346,49 @@ export function RegisterForm() {
                 className={formData.ddi ? "pl-16" : ""}
               />
             </div>
+            <div className="relative">
+              <Input
+                name="password"
+                type={showPassword ? "text" : "password"}
+                placeholder="Senha"
+                value={formData.password}
+                onChange={handleInputChange}
+                disabled={loading}
+                className="pr-10"
 
-            <Input
-              name="password"
-              type="password"
-              placeholder="Senha"
-              value={formData.password}
-              onChange={handleInputChange}
-              disabled={loading}
-            />
 
-            <Input
-              name="confirmPassword"
-              type="password"
-              placeholder="Confirmar senha"
-              value={formData.confirmPassword}
-              onChange={handleInputChange}
-              disabled={loading}
-            />
+              />
+              <button
+                type="button"
+                onClick={togglePassword}
+                aria-label={showPassword ? "ocultar senha" : "mostrar senha"}
+
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500  cursor-pointer  border-none p-0 bg-transparent">
+                {showPassword ? <EyeOff className="w-5 h-5 " /> : <Eye className="w-5 h-5" />}
+              </button>
+            </div>
+            <div className="relative">
+              <Input
+                name="confirmPassword"
+                type={showConfirmPassword ? "text" : "password"}
+                placeholder="Confirmar senha"
+                value={formData.confirmPassword}
+                onChange={handleInputChange}
+                disabled={loading}
+                className="pr-10"
+              />
+              <button
+                type="button"
+                onClick={toggleConfimPassword}
+                aria-label={showConfirmPassword ? "ocultar senha" : "Mostrar senha"}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500  cursor-pointer border-none p-0 bg-transparent"
+
+              >
+                {showConfirmPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
+
+
+              </button>
+            </div>
 
             {/* Terms & Conditions */}
             <div className="flex items-start space-x-2">

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -5,6 +5,7 @@ import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog'
 
 import { cn } from '@/lib/utils'
 import { buttonVariants } from '@/components/ui/button'
+import { Dialog } from '@radix-ui/react-dialog'
 
 function AlertDialog({
   ...props


### PR DESCRIPTION
🛠️ Implementação: Ícone de olho para mostrar/ocultar senha
📌 Descrição
Adicionado ícone de “olho” nos campos de senha das páginas de Login e Registro, permitindo ao usuário alternar a visibilidade da senha digitada.

🚀 Alterações realizadas
Inserido ícone dentro do campo de senha, seguindo o design system do projeto.
Implementada lógica de alternância:
type="password" → type="text" ao clicar no ícone.
Segundo clique retorna para type="password".
Ícone muda conforme o estado (olho aberto/fechado).
Adicionados atributos de acessibilidade (aria-label, role).
Ajustes para garantir responsividade em desktop e mobile.
✅ Critérios atendidos
Usuário consegue ver/ocultar a senha no Login.
Usuário consegue ver/ocultar a senha no Registro.
Layout preservado sem quebras.
Funcionalidade consistente em diferentes dispositivos.
Ícone acessível conforme boas práticas.
<img width="633" height="634" alt="Captura de ecrã de 2026-02-13 14-22-05" src="https://github.com/user-attachments/assets/599814c1-514b-4b75-a712-0dc0a31371c2" />
<img width="633" height="634" alt="Captura de ecrã de 2026-02-13 14-22-36" src="https://github.com/user-attachments/assets/8e051885-4140-4000-85cb-234c4f4b75b1" />
<img width="633" height="634" alt="Captura de ecrã de 2026-02-13 14-22-56" src="https://github.com/user-attachments/assets/67cad163-c228-49a7-a3d0-dc1c554fdaac" />
<img width="633" height="634" alt="Captura de ecrã de 2026-02-13 14-23-05" src="https://github.com/user-attachments/assets/d7e39e60-0081-443f-8e07-f2e9a1b86476" />
