### PR TITLE
feat: Criar tela de cadastro de Produtos para o bot

### DIFF
--- a/app/dashboard/myproducts/page.tsx
+++ b/app/dashboard/myproducts/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Plus, Package, Trash2, Edit2, MessageCircle } from "lucide-react";
 import { MOCK_PRODUCTS, type Product } from "@/mock/products.mock";
@@ -23,16 +23,22 @@ import { Badge } from "@/components/ui/badge";
 import { ProductModal } from "@/components/product-modal";
 import { toast } from "sonner";
 import { Modal } from "@/components/modal";
+import { Sidebar } from "@/components/sidebar";
 
 import { useBots } from "@/hooks/use-bots";
 
 export default function MyProductsPage() {
+  const [hasMounted, setHasMounted] = useState(false);
   const [products, setProducts] = useState<Product[]>(MOCK_PRODUCTS);
   const { bots } = useBots();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [productToEdit, setProductToEdit] = useState<Product | null>(null);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [productToDelete, setProductToDelete] = useState<Product | null>(null);
+
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
 
   const handleSaveProduct = (productData: any) => {
     if (productToEdit) {
@@ -77,126 +83,137 @@ export default function MyProductsPage() {
     }
   };
 
-  return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <h1 className="text-3xl font-bold">Meus Produtos</h1>
-        <Button
-          onClick={() => {
-            setProductToEdit(null);
-            setIsModalOpen(true);
-          }}
-          className="bg-accent hover:bg-accent/90 gap-2 cursor-pointer"
-        >
-          <Plus className="w-4 h-4" />
-          Cadastrar Produto
-        </Button>
-      </div>
+  if (!hasMounted) return null;
 
-      {products.length === 0 ? (
-        <Empty className="mt-12">
-          <EmptyMedia variant="icon">
-            <Package className="w-6 h-6" />
-          </EmptyMedia>
-          <EmptyHeader>
-            <EmptyTitle>Nenhum produto cadastrado</EmptyTitle>
-            <EmptyDescription>
-              Você ainda não possui produtos em sua lista. Comece cadastrando
-              seu primeiro produto.
-            </EmptyDescription>
-          </EmptyHeader>
-          <EmptyContent>
+  return (
+    <div className="flex h-screen bg-background overflow-hidden">
+      <Sidebar />
+      <main className="flex-1 overflow-auto">
+        <div className="p-4 sm:p-6 md:p-8 max-w-7xl mx-auto space-y-6 pt-16 md:pt-8">
+          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+            <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">
+              Meus Produtos
+            </h1>
             <Button
               onClick={() => {
                 setProductToEdit(null);
                 setIsModalOpen(true);
               }}
-              className="bg-accent hover:bg-accent/90 cursor-pointer"
+              className="bg-accent hover:bg-accent/90 gap-2 cursor-pointer w-full sm:w-auto text-sm sm:text-base h-10 sm:h-auto"
             >
+              <Plus className="w-4 h-4" />
               Cadastrar Produto
             </Button>
-          </EmptyContent>
-        </Empty>
-      ) : (
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {products.map((product) => (
-            <Card
-              key={product._id}
-              className="overflow-hidden border-border hover:border-accent/50 transition flex flex-col"
-            >
-              <div className="aspect-square relative overflow-hidden bg-secondary flex items-center justify-center">
-                {product.image ? (
-                  <img
-                    src={product.image}
-                    alt={product.name}
-                    className="w-full h-full object-cover"
-                  />
-                ) : (
-                  <Package className="w-12 h-12 text-muted-foreground/50" />
-                )}
-              </div>
-              <CardHeader className="pb-2">
-                <div className="flex justify-between items-start gap-2">
-                  <CardTitle className="text-xl line-clamp-1">
-                    {product.name}
-                  </CardTitle>
-                  <Badge
-                    variant="secondary"
-                    className="bg-accent/10 text-accent"
-                  >
-                    {product.stock} em estoque
-                  </Badge>
-                </div>
-                <CardDescription className="line-clamp-2 min-h-10">
-                  {product.description}
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="mt-auto">
-                <div className="flex items-center justify-between pt-4 border-t border-border">
-                  <span className="text-xs text-muted-foreground flex items-center gap-1">
-                    <MessageCircle className="w-3 h-3" />
-                    {getBotName(product.botId)}
-                  </span>
-                  <div className="flex gap-2">
-                    <Button
-                      size="icon"
-                      variant="ghost"
-                      className="h-8 w-8 cursor-pointer"
-                      onClick={() => handleEditProduct(product)}
-                    >
-                      <Edit2 className="h-4 w-4" />
-                    </Button>
-                    <Button
-                      size="icon"
-                      variant="ghost"
-                      className="h-8 w-8 text-destructive hover:text-destructive hover:bg-destructive/10 cursor-pointer"
-                      onClick={() => openDeleteDialog(product)}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
+          </div>
+
+          {products.length === 0 ? (
+            <Empty className="mt-8 sm:mt-12">
+              <EmptyMedia variant="icon">
+                <Package className="w-6 h-6" />
+              </EmptyMedia>
+              <EmptyHeader>
+                <EmptyTitle>Nenhum produto cadastrado</EmptyTitle>
+                <EmptyDescription>
+                  Você ainda não possui produtos em sua lista. Comece
+                  cadastrando seu primeiro produto.
+                </EmptyDescription>
+              </EmptyHeader>
+              <EmptyContent>
+                <Button
+                  onClick={() => {
+                    setProductToEdit(null);
+                    setIsModalOpen(true);
+                  }}
+                  className="bg-accent hover:bg-accent/90 cursor-pointer"
+                >
+                  Cadastrar Produto
+                </Button>
+              </EmptyContent>
+            </Empty>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 pb-8">
+              {products.map((product) => (
+                <Card
+                  key={product._id}
+                  className="overflow-hidden border-border hover:border-accent/50 transition flex flex-col group"
+                >
+                  <div className="aspect-video relative overflow-hidden bg-secondary flex items-center justify-center shrink-0">
+                    {product.image ? (
+                      <img
+                        src={product.image}
+                        alt={product.name}
+                        className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
+                      />
+                    ) : (
+                      <Package className="w-12 h-12 text-muted-foreground/30" />
+                    )}
                   </div>
-                </div>
-              </CardContent>
-            </Card>
-          ))}
+                  <CardHeader className="p-4 pb-2">
+                    <div className="flex justify-between items-start gap-2">
+                      <CardTitle className="text-lg font-bold line-clamp-1">
+                        {product.name}
+                      </CardTitle>
+                      <Badge
+                        variant="secondary"
+                        className="bg-accent/10 text-accent text-[10px] px-1.5 shrink-0"
+                      >
+                        {product.stock} un.
+                      </Badge>
+                    </div>
+                    <CardDescription className="line-clamp-2 text-xs min-h-10">
+                      {product.description}
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="p-4 pt-0 mt-auto">
+                    <div className="flex items-center justify-between pt-3 border-t border-border/50">
+                      <span className="text-[10px] sm:text-xs text-muted-foreground flex items-center gap-1.5 truncate pr-2">
+                        <MessageCircle className="w-3 h-3 text-accent shrink-0" />
+                        <span className="truncate">
+                          {getBotName(product.botId)}
+                        </span>
+                      </span>
+                      <div className="flex gap-1 sm:gap-2 shrink-0">
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          className="h-8 w-8 cursor-pointer hover:bg-accent/10 hover:text-accent"
+                          onClick={() => handleEditProduct(product)}
+                        >
+                          <Edit2 className="h-3.5 w-3.5" />
+                        </Button>
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          className="h-8 w-8 text-destructive hover:text-white hover:bg-destructive cursor-pointer transition-colors"
+                          onClick={() => openDeleteDialog(product)}
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </Button>
+                      </div>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+
+          <ProductModal
+            isOpen={isModalOpen}
+            onClose={() => setIsModalOpen(false)}
+            onSave={handleSaveProduct}
+            initialData={productToEdit}
+          />
+
+          <Modal
+            open={isDeleteModalOpen}
+            onOpenChange={setIsDeleteModalOpen}
+            title="Tem certeza que deseja excluir este produto?"
+            description="Essa ação removerá o produto da sua lista permanentemente."
+            confirmText="Excluir"
+            onConfirm={confirmDelete}
+          />
         </div>
-      )}
-
-      <ProductModal
-        isOpen={isModalOpen}
-        onClose={() => setIsModalOpen(false)}
-        onSave={handleSaveProduct}
-        initialData={productToEdit}
-      />
-
-      <Modal
-        open={isDeleteModalOpen}
-        onOpenChange={setIsDeleteModalOpen}
-        title="Tem certeza que deseja excluir este produto?"
-        description="Essa ação removerá o produto da sua lista permanentemente."
-        confirmText="Excluir"
-        onConfirm={confirmDelete}
-      />
+      </main>
     </div>
   );
 }

--- a/app/dashboard/myproducts/page.tsx
+++ b/app/dashboard/myproducts/page.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Plus, Package, Trash2, Edit2, MessageCircle } from "lucide-react";
+import { MOCK_PRODUCTS, type Product } from "@/mock/products.mock";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyMedia,
+} from "@/components/ui/empty";
+import { Badge } from "@/components/ui/badge";
+import { ProductModal } from "@/components/product-modal";
+import { toast } from "sonner";
+import { Modal } from "@/components/modal";
+
+import { useBots } from "@/hooks/use-bots";
+
+export default function MyProductsPage() {
+  const [products, setProducts] = useState<Product[]>(MOCK_PRODUCTS);
+  const { bots } = useBots();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [productToEdit, setProductToEdit] = useState<Product | null>(null);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [productToDelete, setProductToDelete] = useState<Product | null>(null);
+
+  const handleSaveProduct = (productData: any) => {
+    if (productToEdit) {
+      setProducts((prev) =>
+        prev.map((p) =>
+          p._id === productToEdit._id ? { ...p, ...productData } : p,
+        ),
+      );
+      toast.success("Produto atualizado com sucesso!");
+    } else {
+      const newProduct: Product = {
+        _id: Math.random().toString(36).substr(2, 9),
+        ...productData,
+      };
+      setProducts((prev) => [...prev, newProduct]);
+      toast.success("Produto cadastrado com sucesso!");
+    }
+    setProductToEdit(null);
+  };
+
+  const getBotName = (botId: string) => {
+    const bot = bots.find((b: any) => b._id === botId);
+    return bot ? bot.name : "Bot não encontrado";
+  };
+
+  const handleEditProduct = (product: Product) => {
+    setProductToEdit(product);
+    setIsModalOpen(true);
+  };
+
+  const openDeleteDialog = (product: Product) => {
+    setProductToDelete(product);
+    setIsDeleteModalOpen(true);
+  };
+
+  const confirmDelete = async () => {
+    if (productToDelete) {
+      setProducts((prev) => prev.filter((p) => p._id !== productToDelete._id));
+      toast.success("Produto excluído com sucesso!");
+      setIsDeleteModalOpen(false);
+      setProductToDelete(null);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-3xl font-bold">Meus Produtos</h1>
+        <Button
+          onClick={() => {
+            setProductToEdit(null);
+            setIsModalOpen(true);
+          }}
+          className="bg-accent hover:bg-accent/90 gap-2 cursor-pointer"
+        >
+          <Plus className="w-4 h-4" />
+          Cadastrar Produto
+        </Button>
+      </div>
+
+      {products.length === 0 ? (
+        <Empty className="mt-12">
+          <EmptyMedia variant="icon">
+            <Package className="w-6 h-6" />
+          </EmptyMedia>
+          <EmptyHeader>
+            <EmptyTitle>Nenhum produto cadastrado</EmptyTitle>
+            <EmptyDescription>
+              Você ainda não possui produtos em sua lista. Comece cadastrando
+              seu primeiro produto.
+            </EmptyDescription>
+          </EmptyHeader>
+          <EmptyContent>
+            <Button
+              onClick={() => {
+                setProductToEdit(null);
+                setIsModalOpen(true);
+              }}
+              className="bg-accent hover:bg-accent/90 cursor-pointer"
+            >
+              Cadastrar Produto
+            </Button>
+          </EmptyContent>
+        </Empty>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {products.map((product) => (
+            <Card
+              key={product._id}
+              className="overflow-hidden border-border hover:border-accent/50 transition flex flex-col"
+            >
+              <div className="aspect-square relative overflow-hidden bg-secondary flex items-center justify-center">
+                {product.image ? (
+                  <img
+                    src={product.image}
+                    alt={product.name}
+                    className="w-full h-full object-cover"
+                  />
+                ) : (
+                  <Package className="w-12 h-12 text-muted-foreground/50" />
+                )}
+              </div>
+              <CardHeader className="pb-2">
+                <div className="flex justify-between items-start gap-2">
+                  <CardTitle className="text-xl line-clamp-1">
+                    {product.name}
+                  </CardTitle>
+                  <Badge
+                    variant="secondary"
+                    className="bg-accent/10 text-accent"
+                  >
+                    {product.stock} em estoque
+                  </Badge>
+                </div>
+                <CardDescription className="line-clamp-2 min-h-10">
+                  {product.description}
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="mt-auto">
+                <div className="flex items-center justify-between pt-4 border-t border-border">
+                  <span className="text-xs text-muted-foreground flex items-center gap-1">
+                    <MessageCircle className="w-3 h-3" />
+                    {getBotName(product.botId)}
+                  </span>
+                  <div className="flex gap-2">
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="h-8 w-8 cursor-pointer"
+                      onClick={() => handleEditProduct(product)}
+                    >
+                      <Edit2 className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="h-8 w-8 text-destructive hover:text-destructive hover:bg-destructive/10 cursor-pointer"
+                      onClick={() => openDeleteDialog(product)}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      <ProductModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onSave={handleSaveProduct}
+        initialData={productToEdit}
+      />
+
+      <Modal
+        open={isDeleteModalOpen}
+        onOpenChange={setIsDeleteModalOpen}
+        title="Tem certeza que deseja excluir este produto?"
+        description="Essa ação removerá o produto da sua lista permanentemente."
+        confirmText="Excluir"
+        onConfirm={confirmDelete}
+      />
+    </div>
+  );
+}

--- a/app/dashboard/myproducts/page.tsx
+++ b/app/dashboard/myproducts/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Plus, Package, Trash2, Edit2, MessageCircle } from "lucide-react";
-import { MOCK_PRODUCTS, type Product } from "@/mock/products.mock";
+import { type Product } from "@/mock/products.mock";
 import {
   Card,
   CardContent,
@@ -26,10 +26,13 @@ import { Modal } from "@/components/modal";
 import { Sidebar } from "@/components/sidebar";
 
 import { useBots } from "@/hooks/use-bots";
+import { useProducts } from "@/hooks/use-products";
+import { Spinner } from "@/components/ui/spinner";
 
 export default function MyProductsPage() {
   const [hasMounted, setHasMounted] = useState(false);
-  const [products, setProducts] = useState<Product[]>(MOCK_PRODUCTS);
+  const { products, isLoading, createProduct, updateProduct, deleteProduct } =
+    useProducts();
   const { bots } = useBots();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [productToEdit, setProductToEdit] = useState<Product | null>(null);
@@ -40,21 +43,17 @@ export default function MyProductsPage() {
     setHasMounted(true);
   }, []);
 
-  const handleSaveProduct = (productData: any) => {
-    if (productToEdit) {
-      setProducts((prev) =>
-        prev.map((p) =>
-          p._id === productToEdit._id ? { ...p, ...productData } : p,
-        ),
-      );
-      toast.success("Produto atualizado com sucesso!");
-    } else {
-      const newProduct: Product = {
-        _id: Math.random().toString(36).substr(2, 9),
-        ...productData,
-      };
-      setProducts((prev) => [...prev, newProduct]);
-      toast.success("Produto cadastrado com sucesso!");
+  const handleSaveProduct = async (productData: any) => {
+    try {
+      if (productToEdit) {
+        await updateProduct(productToEdit._id, productData);
+        toast.success("Produto atualizado com sucesso!");
+      } else {
+        await createProduct(productData);
+        toast.success("Produto cadastrado com sucesso!");
+      }
+    } catch (error) {
+      toast.error("Ocorreu um erro ao salvar o produto.");
     }
     setProductToEdit(null);
   };
@@ -76,14 +75,24 @@ export default function MyProductsPage() {
 
   const confirmDelete = async () => {
     if (productToDelete) {
-      setProducts((prev) => prev.filter((p) => p._id !== productToDelete._id));
-      toast.success("Produto excluído com sucesso!");
+      try {
+        await deleteProduct(productToDelete._id);
+        toast.success("Produto excluído com sucesso!");
+      } catch (error) {
+        toast.error("Ocorreu um erro ao excluir o produto.");
+      }
       setIsDeleteModalOpen(false);
       setProductToDelete(null);
     }
   };
 
-  if (!hasMounted) return null;
+  if (!hasMounted || isLoading) {
+    return (
+      <div className="flex h-screen items-center justify-center bg-background">
+        <Spinner className="size-8" />
+      </div>
+    );
+  }
 
   return (
     <div className="flex h-screen bg-background overflow-hidden">

--- a/components/product-modal.tsx
+++ b/components/product-modal.tsx
@@ -1,0 +1,333 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useBots } from "@/hooks/use-bots";
+import { ImagePlus, X, AlertCircle, CheckCircle2 } from "lucide-react";
+import { Spinner } from "@/components/ui/spinner";
+
+interface ProductModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (product: any) => void;
+  initialData?: any;
+}
+
+export function ProductModal({
+  isOpen,
+  onClose,
+  onSave,
+  initialData,
+}: ProductModalProps) {
+  const { bots, isLoading: isLoadingBots } = useBots();
+  const [loading, setLoading] = useState(false);
+  const [formData, setFormData] = useState({
+    name: "",
+    description: "",
+    stock: 0,
+    botId: "",
+  });
+  const [image, setImage] = useState<File | null>(null);
+  const [imagePreview, setImagePreview] = useState<string>("");
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  useEffect(() => {
+    if (initialData && isOpen) {
+      setFormData({
+        name: initialData.name || "",
+        description: initialData.description || "",
+        stock: initialData.stock || 0,
+        botId: initialData.botId || "",
+      });
+      setImagePreview(initialData.image || "");
+      setImage(null); // Assuming image is handled by preview if not changed
+    } else if (isOpen) {
+      resetForm();
+    }
+  }, [initialData, isOpen]);
+
+  const validate = () => {
+    const newErrors: Record<string, string> = {};
+    if (!formData.name.trim()) newErrors.name = "Nome do produto é obrigatório";
+    if (!formData.description.trim())
+      newErrors.description = "Descrição é obrigatória";
+    if (formData.stock < 0) newErrors.stock = "Estoque não pode ser negativo";
+    if (!formData.botId) newErrors.botId = "Selecione um Bot";
+    if (!imagePreview) newErrors.image = "Foto do produto é obrigatória";
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      if (!["image/jpeg", "image/jpg", "image/png"].includes(file.type)) {
+        setErrors((prev) => ({
+          ...prev,
+          image: "Apenas arquivos .jpg, .jpeg ou .png são permitidos",
+        }));
+        return;
+      }
+      setImage(file);
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        setImagePreview(reader.result as string);
+      };
+      reader.readAsDataURL(file);
+      setErrors((prev) => {
+        const { image, ...rest } = prev;
+        return rest;
+      });
+    }
+  };
+
+  const removeImage = () => {
+    setImage(null);
+    setImagePreview("");
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!validate()) return;
+
+    setLoading(true);
+    // Simulating API call
+    setTimeout(() => {
+      onSave({
+        ...formData,
+        image: imagePreview,
+      });
+      resetForm();
+      setLoading(false);
+      onClose();
+    }, 1000);
+  };
+
+  const resetForm = () => {
+    setFormData({
+      name: "",
+      description: "",
+      stock: 0,
+      botId: "",
+    });
+    setImage(null);
+    setImagePreview("");
+    setErrors({});
+  };
+
+  const isFormValid =
+    formData.name &&
+    formData.description &&
+    formData.botId &&
+    image &&
+    formData.stock >= 0;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="sm:max-w-[500px] overflow-y-auto max-h-[90vh]">
+        <DialogHeader>
+          <DialogTitle className="text-2xl font-bold">
+            Cadastrar Produto
+          </DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-6 pt-4">
+          <div className="space-y-2">
+            <Label htmlFor="product-name">Nome do Produto</Label>
+            <Input
+              id="product-name"
+              placeholder="Ex: Camiseta Básica"
+              value={formData.name}
+              onChange={(e) =>
+                setFormData({ ...formData, name: e.target.value })
+              }
+              className={errors.name ? "border-destructive" : ""}
+            />
+            {errors.name && (
+              <p className="text-xs text-destructive flex items-center gap-1">
+                <AlertCircle className="w-3 h-3" /> {errors.name}
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="product-description">Descrição</Label>
+            <Textarea
+              id="product-description"
+              placeholder="Descreva detalhes do produto..."
+              rows={3}
+              value={formData.description}
+              onChange={(e) =>
+                setFormData({ ...formData, description: e.target.value })
+              }
+              className={errors.description ? "border-destructive" : ""}
+            />
+            {errors.description && (
+              <p className="text-xs text-destructive flex items-center gap-1">
+                <AlertCircle className="w-3 h-3" /> {errors.description}
+              </p>
+            )}
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="product-stock">Estoque</Label>
+              <Input
+                id="product-stock"
+                type="number"
+                min="0"
+                value={formData.stock}
+                onChange={(e) =>
+                  setFormData({
+                    ...formData,
+                    stock: parseInt(e.target.value) || 0,
+                  })
+                }
+                className={errors.stock ? "border-destructive" : ""}
+              />
+              {errors.stock && (
+                <p className="text-xs text-destructive flex items-center gap-1">
+                  <AlertCircle className="w-3 h-3" /> {errors.stock}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="product-bot">Bot Vinculado</Label>
+              <Select
+                value={formData.botId}
+                onValueChange={(value) =>
+                  setFormData({ ...formData, botId: value })
+                }
+              >
+                <SelectTrigger
+                  className={
+                    errors.botId ? "border-destructive w-full" : "w-full"
+                  }
+                >
+                  <SelectValue
+                    placeholder={
+                      isLoadingBots ? "Carregando bots..." : "Selecione um Bot"
+                    }
+                  />
+                </SelectTrigger>
+                <SelectContent>
+                  {isLoadingBots ? (
+                    <div className="p-2 flex items-center justify-center">
+                      <Spinner className="size-4" />
+                    </div>
+                  ) : bots.length === 0 ? (
+                    <div className="p-2 text-sm text-center text-muted-foreground">
+                      Nenhum bot encontrado
+                    </div>
+                  ) : (
+                    bots.map((bot: any) => (
+                      <SelectItem key={bot._id} value={bot._id}>
+                        {bot.name}
+                      </SelectItem>
+                    ))
+                  )}
+                </SelectContent>
+              </Select>
+              {errors.botId && (
+                <p className="text-xs text-destructive flex items-center gap-1">
+                  <AlertCircle className="w-3 h-3" /> {errors.botId}
+                </p>
+              )}
+              {bots.length === 0 && !isLoadingBots && (
+                <p className="text-xs text-amber-500">
+                  Cadastre um bot primeiro para vincular produtos.
+                </p>
+              )}
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            <Label>Foto do Produto</Label>
+            {!imagePreview ? (
+              <div
+                className={`border-2 border-dashed rounded-lg p-8 flex flex-col items-center justify-center gap-2 cursor-pointer hover:bg-secondary/50 transition ${errors.image ? "border-destructive bg-destructive/5" : "border-border"}`}
+                onClick={() =>
+                  document.getElementById("product-image")?.click()
+                }
+              >
+                <ImagePlus className="w-10 h-10 text-muted-foreground" />
+                <span className="text-sm text-muted-foreground font-medium">
+                  Clique para fazer upload
+                </span>
+                <span className="text-xs text-muted-foreground/60">
+                  Apenas JPG ou PNG
+                </span>
+                <input
+                  id="product-image"
+                  type="file"
+                  accept="image/jpeg, image/jpg, image/png"
+                  className="hidden"
+                  onChange={handleImageChange}
+                />
+              </div>
+            ) : (
+              <div className="relative rounded-lg overflow-hidden border border-border aspect-video bg-secondary">
+                <img
+                  src={imagePreview}
+                  alt="Preview"
+                  className="w-full h-full object-contain"
+                />
+                <button
+                  type="button"
+                  onClick={removeImage}
+                  className="absolute top-2 right-2 bg-black/60 text-white p-1 rounded-full hover:bg-black/80 transition"
+                >
+                  <X className="w-4 h-4" />
+                </button>
+              </div>
+            )}
+            {errors.image && (
+              <p className="text-xs text-destructive flex items-center gap-1">
+                <AlertCircle className="w-3 h-3" /> {errors.image}
+              </p>
+            )}
+          </div>
+
+          <DialogFooter className="gap-2 sm:gap-0">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onClose}
+              disabled={loading}
+              className="cursor-pointer"
+            >
+              Cancelar
+            </Button>
+            <Button
+              type="submit"
+              disabled={loading || !isFormValid || bots.length === 0}
+              className="bg-accent hover:bg-accent/90 cursor-pointer"
+            >
+              {loading ? <Spinner className="mr-2 h-4 w-4" /> : null}
+              {loading ? "Salvando..." : "Salvar Produto"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/product-modal.tsx
+++ b/components/product-modal.tsx
@@ -104,21 +104,22 @@ export function ProductModal({
     setImagePreview("");
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!validate()) return;
 
     setLoading(true);
-    // Simulating API call
-    setTimeout(() => {
-      onSave({
+    try {
+      await onSave({
         ...formData,
         image: imagePreview,
       });
       resetForm();
-      setLoading(false);
       onClose();
-    }, 1000);
+    } catch (error) {
+    } finally {
+      setLoading(false);
+    }
   };
 
   const resetForm = () => {

--- a/components/product-modal.tsx
+++ b/components/product-modal.tsx
@@ -187,7 +187,7 @@ export function ProductModal({
             )}
           </div>
 
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div className="space-y-2">
               <Label htmlFor="product-stock">Estoque</Label>
               <Input

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -1,27 +1,35 @@
-"use client"
+"use client";
 
-import Link from "next/link"
-import { usePathname, useRouter } from "next/navigation"
-import { Button } from "@/components/ui/button"
-import { useAuth } from "@/hooks/use-auth"
-import { MessageCircle, Settings, LogOut, Menu, X } from "lucide-react"
-import { useState } from "react"
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/hooks/use-auth";
+import {
+  MessageCircle,
+  Settings,
+  LogOut,
+  Menu,
+  X,
+  Package,
+} from "lucide-react";
 
 export function Sidebar() {
-  const pathname = usePathname()
-  const router = useRouter()
-  const { logout } = useAuth()
-  const [open, setOpen] = useState(false)
+  const pathname = usePathname();
+  const router = useRouter();
+  const { logout } = useAuth();
+  const [open, setOpen] = useState(false);
 
   const navItems = [
     { href: "/dashboard", label: "Meus Bots", icon: MessageCircle },
+    { href: "/dashboard/myproducts", label: "Meus Produtos", icon: Package },
     { href: "/dashboard/settings", label: "Configurações", icon: Settings },
-  ]
+  ];
 
   const handleLogout = () => {
-    logout()
-    router.push("/login")
-  }
+    logout();
+    router.push("/login");
+  };
 
   return (
     <>
@@ -55,24 +63,23 @@ export function Sidebar() {
             className="flex items-center gap-2 hover:opacity-80 transition"
           >
             <div className="w-8 h-8 rounded-lg bg-sidebar-primary flex items-center justify-center">
-              <span className="text-sidebar-primary-foreground font-bold text-sm">UB</span>
+              <span className="text-sidebar-primary-foreground font-bold text-sm">
+                UB
+              </span>
             </div>
             <h1 className="font-bold text-lg">U Bot</h1>
           </Link>
 
           {/* Botão fechar só aparece em mobile */}
-          <button
-            className="md:hidden"
-            onClick={() => setOpen(false)}
-          >
+          <button className="md:hidden" onClick={() => setOpen(false)}>
             <X className="w-6 h-6 text-sidebar-primary-foreground" />
           </button>
         </div>
 
         <nav className="flex-1 p-4 space-y-2">
           {navItems.map((item) => {
-            const Icon = item.icon
-            const isActive = pathname === item.href
+            const Icon = item.icon;
+            const isActive = pathname === item.href;
 
             return (
               <Link
@@ -88,7 +95,7 @@ export function Sidebar() {
                 <Icon className="w-5 h-5" />
                 <span className="text-sm">{item.label}</span>
               </Link>
-            )
+            );
           })}
         </nav>
 
@@ -104,5 +111,5 @@ export function Sidebar() {
         </div>
       </aside>
     </>
-  )
+  );
 }

--- a/hooks/use-products.ts
+++ b/hooks/use-products.ts
@@ -1,0 +1,63 @@
+import useSWR from "swr";
+import { productApi } from "@/lib/api-client";
+import { type Product } from "@/mock/products.mock";
+
+function extractProductsList(payload: any): Product[] {
+    if (Array.isArray(payload)) return payload;
+    if (Array.isArray(payload?.data)) return payload.data;
+    if (Array.isArray(payload?.products)) return payload.products;
+    if (Array.isArray(payload?.data?.products)) return payload.data.products;
+    return [];
+}
+
+function extractProductItem(payload: any): Product {
+    if (!payload) return payload;
+    return payload?.data?.product ?? payload?.data ?? payload?.product ?? payload;
+}
+
+export function useProducts() {
+    const {
+        data,
+        error,
+        isLoading,
+        mutate,
+    } = useSWR("/products", () => productApi.list(), {
+        revalidateOnFocus: false,
+        revalidateOnReconnect: false,
+    });
+
+    const products = extractProductsList(data);
+
+    const createProduct = async (data: any) => {
+        const response = await productApi.create(data);
+        const newProduct = extractProductItem(response);
+        mutate((prev: any) => [...extractProductsList(prev), newProduct], false);
+        return newProduct;
+    };
+
+    const updateProduct = async (id: string, data: any) => {
+        const response = await productApi.update(id, data);
+        const updated = extractProductItem(response);
+        mutate(
+            (prev: any) =>
+                extractProductsList(prev).map((product: Product) => (product._id === id ? updated : product)),
+            false,
+        );
+        return updated;
+    };
+
+    const deleteProduct = async (id: string) => {
+        await productApi.delete(id);
+        mutate((prev: any) => extractProductsList(prev).filter((product: Product) => product._id !== id), false);
+    };
+
+    return {
+        products,
+        isLoading,
+        error,
+        createProduct,
+        updateProduct,
+        deleteProduct,
+        mutate,
+    };
+}

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -194,3 +194,26 @@ export const planApi = {
       body: JSON.stringify({ planName, status }),
     }),
 };
+
+export const productApi = {
+  list: () => apiCall("/products"),
+
+  create: (data: any) =>
+    apiCall("/products", {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
+
+  get: (id: string) => apiCall(`/products/${id}`),
+
+  update: (id: string, data: any) =>
+    apiCall(`/products/${id}`, {
+      method: "PUT",
+      body: JSON.stringify(data),
+    }),
+
+  delete: (id: string) =>
+    apiCall(`/products/${id}`, {
+      method: "DELETE",
+    }),
+};

--- a/mock/products.mock.ts
+++ b/mock/products.mock.ts
@@ -1,0 +1,34 @@
+
+export interface Product {
+    _id: string;
+    name: string;
+    description: string;
+    stock: number;
+    botId: string;
+    image: string;
+}
+
+export const MOCK_PRODUCTS: Product[] = [
+    {
+        _id: "1",
+        name: "Produto Exemplo 1",
+        description: "Descrição do produto exemplo 1",
+        stock: 10,
+        botId: "bot-1",
+        image: "https://via.placeholder.com/150",
+    },
+    {
+        _id: "2",
+        name: "Produto Exemplo 2",
+        description: "Descrição do produto exemplo 2",
+        stock: 5,
+        botId: "bot-2",
+        image: "https://via.placeholder.com/150",
+    },
+];
+
+export const MOCK_BOTS = [
+    { _id: "bot-1", name: "Bot de Atendimento" },
+    { _id: "bot-2", name: "Bot de Vendas" },
+    { _id: "bot-3", name: "Bot de Suporte" },
+];


### PR DESCRIPTION
## **🎯 Objetivo**
Implementação completa da nova seção "Meus Produtos" no painel do sistema. Esta funcionalidade permite que o usuário gerencie seu catálogo de produtos, vinculando-os aos seus Bots ativos de forma intuitiva e responsiva.

### **🛠️ O que foi feito:**
**Navegação & Layout:**
Adição do item "Meus Produtos" ao menu lateral (Sidebar).
Integração do layout global (com menu hambúrguer) em toda a seção de produtos.
Página de Listagem (/dashboard/myproducts):
Desenvolvimento de grid responsivo de produtos.
Mapeamento dinâmico de IDs para nomes de Bots reais (consumindo o hook useBots).
Implementação de estado vazio (Empty State) personalizado.

**Gestão de Produtos (CRUD):**
Cadastro & Edição: Modal unificado para criar e atualizar produtos.
Validação de Formulário: Tratamento de erros para campos obrigatórios, estoque negativo e tipos de arquivos.
Upload de Imagem: Sistema de preview em tempo real com suporte a arquivo único (JPG/PNG).
Exclusão: Diálogo de confirmação para remoção segura de itens.

### **Excelência em UX & Responsividade:**
Suporte completo para dispositivos móveis a partir de 320px.
Ajuste automático de escala nos cards e cabeçalhos para evitar sobreposições em telas pequenas.
Feedback visual instantâneo via sonner toasts.

**Refatoração e Performance:**
Correção de erro de Hydration Mismatch do Next.js usando o pattern hasMounted.
Otimização de classes CSS/Tailwind para melhor densidade de informação em mobile.

### **📸 Screenshots / Demonstração**

https://github.com/user-attachments/assets/6c7b0f77-cac4-4780-95d9-5765c6a781e9